### PR TITLE
Replace templated links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,14 @@ Thanks for considering contributing to Default!
 
 ## Opening issues
 
-If you find a bug, please feel free to [open an issue](https://github.com/kennethormandy/default/issues).
+If you find a bug, please feel free to [open an issue](https://github.com/MohGovIL/hamagen-react-native/issues).
 
 If you taking the time to mention a problem, even a seemingly minor one, it is greatly appreciated, and a totally valid contribution to this project. Thank you!
 
 
 ## Adding new features
 
-Thinking of adding a new feature? Cool! [Open an issue](https://github.com/kennethormandy/default/issues) and let’s design it together.
+Thinking of adding a new feature? Cool! [Open an issue](https://github.com/MohGovIL/hamagen-react-native/issues) and let’s design it together.
 
 ## Fixing bugs
 


### PR DESCRIPTION
Hi,
It seems like these links were left here by accidents from the original template.
Replaced them with the corresponding links to this repository. 