### PR TITLE
Use env vars for the release keystore passwords. the release keystore WAS NOT exposed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ Make sure your app is [`debuggable`](https://developer.android.com/guide/topics/
 $ adb exec-out run-as com.hamagen.dev cat databases/Reactoffline.db > app_db.sqlite
 ~~~
 
+## Release
+
+Please make sure that you have the following environment variables set:
+
+~~~
+HAMAGEN_KEYSTORE_PATH = '../path/to/release.keystore'
+HAMAGEN_STORE_PASSWORD= 'release store password'
+HAMAGEN_KEY_ALIAS= 'release key alias'
+HAMAGEN_KEY_PASSWORD= 'release key password'
+~~~
+
 ## License
 
 MIT

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -165,10 +165,10 @@ android {
             keyPassword 'android'
         }
         release {
-            storeFile releaseKeystore
-            storePassword 'hamagen123'
-            keyAlias 'hamagen'
-            keyPassword 'hamagen123'
+            storeFile file(System.getenv("HAMAGEN_KEYSTORE_PATH"))
+            storePassword System.getenv("HAMAGEN_STORE_PASSWORD")
+            keyAlias System.getenv('HAMAGEN_KEY_ALIAS')
+            keyPassword System.getenv('HAMAGEN_KEY_PASSWORD')
         }
     }
 


### PR DESCRIPTION
Closes #17. The release keystore *WAS NOT* - therefore, to our knowledge, an attacker can't do much with only the passwords.

Nevertheless, we're generating a new release keystore with new, safer, stronger passwords.