### PR TITLE
easy script for self building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,13 @@ keystore.properties
 *.keystore
 debug.keystore
 
+
+# compile.sh
+*.pfx
+magen_keystore.pass
+app-release.apk
+image.tag
+
 # fastlane
 #
 # It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y  --no-install-recommends \
+  git \
+  curl \
+  wget \
+  unzip \
+  openjdk-8-jdk && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN curl -sL https://deb.nodesource.com/setup_13.x | bash - && \
+    apt-get update && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /magen/sdk
+RUN wget https://dl.google.com/android/repository/commandlinetools-linux-6200805_latest.zip && \
+    unzip commandlinetools-linux-6200805_latest.zip && \
+    rm commandlinetools-linux-6200805_latest.zip
+
+ENV ANDROID_SDK_ROOT="/magen/sdk"
+ENV ANDROID_HOME="${ANDROID_SDK_ROOT}"
+ENV PATH="${PATH}:${ANDROID_HOME}/emulator"
+ENV PATH="${PATH}:${ANDROID_HOME}/tools"
+ENV PATH="${PATH}:${ANDROID_HOME}/tools/bin"
+ENV PATH="${PATH}:${ANDROID_HOME}/platform-tools"
+
+RUN yes | $ANDROID_HOME/tools/bin/sdkmanager --sdk_root=${ANDROID_HOME} --licenses
+RUN $ANDROID_HOME/tools/bin/sdkmanager --sdk_root=${ANDROID_HOME} --update
+RUN $ANDROID_HOME/tools/bin/sdkmanager --sdk_root=${ANDROID_HOME} "platform-tools" "platforms;android-28"
+
+WORKDIR /magen
+
+RUN git clone --depth 1 https://github.com/MohGovIL/hamagen-react-native.git
+WORKDIR /magen/hamagen-react-native
+RUN npm install
+RUN cd android && ./gradlew | true 2>/dev/null
+
+CMD /bin/bash

--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -x
+PASS_FILE="magen_keystore.pass"
+KEYSTORE_FILE="magen.pfx"
+IMAGE_TAG_FILE="image.tag"
+ALIAS="magen"
+
+GUES_PATH=/magen/hamagen-react-native
+
+
+if [ -f $IMAGE_TAG_FILE ]; then
+    IMAGETAG=$(cat $IMAGE_TAG_FILE);
+else
+    IMAGETAG=$(head -c 12 /dev/urandom | sha256sum | head -c 12);
+    docker build . -t $IMAGETAG
+    echo $IMAGETAG > $IMAGE_TAG_FILE;
+fi
+
+# Check we have the password.
+if [ -f $PASS_FILE ]; then
+    KEYSTORE_PASS=$(cat magen_keystore.pass);
+else
+    KEYSTORE_PASS=$(head -c 32 /dev/urandom | sha256sum | head -c 64);
+    echo $KEYSTORE_PASS > $PASS_FILE;
+fi
+
+# Check we have the keystore.
+
+if [ ! -f $KEYSTORE_FILE ]; then
+    keytool -genkey -alias $ALIAS -keystore $KEYSTORE_FILE -storetype PKCS12 -keyalg RSA -keysize 4096 -storepass $KEYSTORE_PASS -keypass $KEYSTORE_PASS -validity 10000 -dname CN=IL;
+fi
+
+HAMAGEN_KEY_PASSWORD=$HAMAGEN_STORE_PASSWORD
+
+KEYSTORE_FILE="$GUES_PATH/$KEYSTORE_FILE"
+docker run -v `pwd`:$GUES_PATH $IMAGETAG bash -c \
+    "cd ./android && \
+    HAMAGEN_KEYSTORE_PATH=$KEYSTORE_FILE \
+    HAMAGEN_KEY_PASSWORD=$KEYSTORE_PASS \
+    HAMAGEN_STORE_PASSWORD=$KEYSTORE_PASS \
+    HAMAGEN_KEY_ALIAS=$ALIAS \
+    HAMAGEN_DEBUG_KEYSTORE_PATH=dummy \
+    HAMAGEN_DEBUG_STORE_PASSWORD=dummy \
+    HAMAGEN_DEBUG_KEY_ALIAS=dummy \
+    HAMAGEN_DEBUG_KEY_PASSWORD=dummy \
+    ./gradlew assembleRelease && \
+    cp ./app/build/outputs/apk/release/app-release.apk ../";


### PR DESCRIPTION
Hi,
It's probably not a priority for you, but still an issue for security conscious people is that I want to know that the code in google-play is the same as in the code I've reviewed.
The ideal solution would be reproducible deterministic builds, and a way to easily compare the hashes.

But for now self compiling is also a great option. so this scripts abstract out all the weird complexities android sdk has and all the environment variables.
and it also provides a persistent self generated keystore.    