### PR TITLE
Added check for activity type to remove false positives

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ import { onError } from './src/services/ErrorService';
 BackgroundGeolocation.onLocation(
   async (location) => {
     location.timestamp = moment(location.timestamp).valueOf();
-    if (location.event.type != 'in_vehicle') {
+    if (location.event.type !== 'in_vehicle') {
       await insertDB(location);
     }
   }, (error) => {

--- a/index.js
+++ b/index.js
@@ -12,7 +12,9 @@ import { onError } from './src/services/ErrorService';
 BackgroundGeolocation.onLocation(
   async (location) => {
     location.timestamp = moment(location.timestamp).valueOf();
-    await insertDB(location);
+    if (location.event.type != 'in_vehicle') {
+      await insertDB(location);
+    }
   }, (error) => {
     onError({ error });
   }


### PR DESCRIPTION
Added check for `location.event.type !== 'in_vehicle'` to remove false positives, when driving by locations (like the example from the [ynet article](https://www.ynet.co.il/digital/technews/article/S1GKAonLU))
See documentation [here](https://transistorsoft.github.io/react-native-background-geolocation/interfaces/_react_native_background_geolocation_.motionactivityevent.html).
The event should come with each location update.
Note that the `confidence` parameter is always at 100% on android ([source](https://transistorsoft.github.io/react-native-background-geolocation/classes/_react_native_background_geolocation_.backgroundgeolocation.html#onactivitychange)).